### PR TITLE
feat: Initiating Leaderboard stat service#32

### DIFF
--- a/leaderboardstatapp/delivery/http/handler.go
+++ b/leaderboardstatapp/delivery/http/handler.go
@@ -1,0 +1,53 @@
+package http
+
+import (
+	"github.com/gocasters/rankr/leaderboardstatapp/service/leaderboardstat"
+	"github.com/labstack/echo/v4"
+	"log/slog"
+	"net/http"
+	"strconv"
+)
+
+type Handler struct {
+	LeaderboardStatService leaderboardstat.Service
+	Logger                 *slog.Logger
+}
+
+func NewHandler(leaderboardStatService leaderboardstat.Service, logger *slog.Logger) *Handler {
+	return &Handler{
+		LeaderboardStatService: leaderboardStatService,
+		Logger:                 logger,
+	}
+}
+
+func (h Handler) GetLeaderboards(c echo.Context) error {
+	var req leaderboardstat.LeaderboardFilterRequest
+
+	if err := c.Bind(&req); err != nil {
+		return err
+	}
+
+	response, err := h.LeaderboardStatService.GetLeaderboardByFilters(c.Request().Context(), req)
+
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, response)
+}
+
+func (h Handler) GetContributorStats(c echo.Context) error {
+	var contributorID int
+	var err error
+
+	if contributorID, err = strconv.Atoi(c.Param("id")); err != nil {
+		// TODO - use error pattern
+		return err
+	}
+
+	response, err := h.LeaderboardStatService.GetContributorStats(c.Request().Context(), contributorID)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, response)
+}

--- a/leaderboardstatapp/delivery/http/health_check.go
+++ b/leaderboardstatapp/delivery/http/health_check.go
@@ -1,0 +1,13 @@
+package http
+
+import (
+	"net/http"
+
+	echo "github.com/labstack/echo/v4"
+)
+
+func (s Server) healthCheck(c echo.Context) error {
+	return c.JSON(http.StatusOK, echo.Map{
+		"message": "everything is good!",
+	})
+}

--- a/leaderboardstatapp/delivery/http/server.go
+++ b/leaderboardstatapp/delivery/http/server.go
@@ -1,0 +1,47 @@
+package http
+
+import (
+	"fmt"
+	"strconv"
+
+	httpserver "github.com/gocasters/rankr/pkg/httpserver"
+)
+
+type Server struct {
+	HTTPServer httpserver.Server
+	Handler    Handler
+}
+
+func New(server httpserver.Server, handler Handler) Server {
+	return Server{
+		HTTPServer: server,
+		Handler:    handler,
+	}
+}
+
+func (s Server) Serve() {
+	s.RegisterRoutes()
+
+	fmt.Printf("start echo server on %s\n", strconv.Itoa(s.HTTPServer.GetConfig().Port))
+	if err := s.HTTPServer.Start(); err != nil {
+		fmt.Println("router start error", err)
+	}
+}
+
+func (s Server) RegisterRoutes() {
+	// TODO- Add tracing middleware
+
+	// create v1 group
+	v1 := s.HTTPServer.GetRouter().Group("/v1")
+	v1.GET("/health-check", s.healthCheck)
+
+	// leaderboard group
+	leaderboardGroup := v1.Group("/leaderboard")
+	leaderboardGroup.GET("/", s.Handler.GetLeaderboards)
+	//leaderboardGroup.GET("/:project", s.Handler.GetLeaderboard)
+
+	// contributor group
+	contributorGroup := v1.Group("/contributors")
+	contributorGroup.GET("/:id/stats", s.Handler.GetContributorStats)
+	//contributorGroup.GET("/:id/rank", s.Handler.GetContributorRank)
+}

--- a/leaderboardstatapp/repository/redis/db.go
+++ b/leaderboardstatapp/repository/redis/db.go
@@ -1,0 +1,11 @@
+package redis
+
+import "github.com/gocasters/rankr/adapter/redis"
+
+type DB struct {
+	adapter redis.Adapter
+}
+
+func New(adapter redis.Adapter) DB {
+	return DB{adapter: adapter}
+}

--- a/leaderboardstatapp/repository/redis/leaderboardstat.go
+++ b/leaderboardstatapp/repository/redis/leaderboardstat.go
@@ -1,0 +1,101 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"github.com/gocasters/rankr/leaderboardstatapp/service/leaderboardstat"
+	"github.com/redis/go-redis/v9"
+	"strconv"
+)
+
+type LeaderboardRepo struct {
+	Redis *redis.Client
+}
+
+func NewLeaderboardRepo(redis *redis.Client) *LeaderboardRepo {
+	return &LeaderboardRepo{}
+}
+
+func (d DB) GetLeaderboardByFilters(ctx context.Context, page int, pageSize int, category string, timeframe string) (leaderboardstat.ScoreboardResponse, error) {
+
+	key := fmt.Sprintf("%s:%s", category, timeframe)
+	client := d.adapter.Client()
+	list, err := client.ZRevRangeWithScores(ctx,
+		key,
+		int64((page-1)*pageSize),
+		int64(page*pageSize-1),
+	).Result()
+
+	if err != nil {
+		return leaderboardstat.ScoreboardResponse{}, fmt.Errorf("failed to get leaderboard: %w", err)
+	}
+
+	fmt.Println(list)
+
+	var response leaderboardstat.ScoreboardResponse
+	for _, z := range list {
+
+		contributorID, err := strconv.Atoi(z.Member.(string))
+		if err != nil {
+			return leaderboardstat.ScoreboardResponse{}, fmt.Errorf("invalid contributor ID format: %w", err)
+		}
+
+		rank, err := client.ZRevRank(ctx, key, z.Member.(string)).Result()
+		if err != nil {
+			return leaderboardstat.ScoreboardResponse{}, fmt.Errorf("failed to get rank: %w", err)
+		}
+
+		response.Entries = append(response.Entries, leaderboardstat.ScoreboardItem{
+			Rank:          int(rank) + 1,
+			ContributorID: contributorID,
+			Score:         int(z.Score),
+		})
+	}
+
+	return response, nil
+}
+
+func (d DB) CreateNewScoreList(ctx context.Context, redisKey string, entries []leaderboardstat.LeaderboardEntry) error {
+	client := d.adapter.Client()
+	pipe := client.Pipeline()
+
+	// Delete existing key to replace with fresh data
+	pipe.Del(ctx, redisKey)
+
+	// Prepare ZADD commands for all entries
+	zMembers := make([]redis.Z, len(entries))
+	for i, entry := range entries {
+		zMembers[i] = redis.Z{
+			Score:  float64(entry.Score),
+			Member: entry.ContributorID,
+		}
+	}
+
+	pipe.ZAdd(ctx, redisKey, zMembers...)
+
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+func (d DB) BulkCreateScoreLists(ctx context.Context, keys []string, entries []leaderboardstat.LeaderboardEntry) error {
+	client := d.adapter.Client()
+	pipe := client.Pipeline()
+
+	for _, key := range keys {
+		// Prepare Z members for each key
+		zMembers := make([]redis.Z, len(entries))
+		for i, entry := range entries {
+			zMembers[i] = redis.Z{
+				Score:  float64(entry.Score),
+				Member: entry.ContributorID,
+			}
+		}
+
+		// Clear existing and add new entries
+		pipe.Del(ctx, key)
+		pipe.ZAdd(ctx, key, zMembers...)
+	}
+
+	_, err := pipe.Exec(ctx)
+	return err
+}

--- a/leaderboardstatapp/service/leaderboardstat/entity.go
+++ b/leaderboardstatapp/service/leaderboardstat/entity.go
@@ -1,0 +1,20 @@
+package leaderboardstat
+
+type ScoreboardItem struct {
+	Rank          int `koanf:"rank"`
+	ContributorID int `koanf:"contributor_id"`
+	Score         int `koanf:"score"`
+}
+
+type LeaderboardEntry struct {
+	ContributorID string `koanf:"contributor_id"`
+	Score         int    `koanf:"score"`
+}
+
+type ContributorStat struct {
+	ContributorID int            `koanf:"contributor_id"`
+	GlobalRank    int            `koanf:"global_rank"`
+	TotalScore    int            `koanf:"total_score"`
+	ProjectScore  map[string]int `koanf:"project_ranks"`
+	ScoreHistory  map[string]int `koanf:"score_history"`
+}

--- a/leaderboardstatapp/service/leaderboardstat/param.go
+++ b/leaderboardstatapp/service/leaderboardstat/param.go
@@ -1,0 +1,24 @@
+package leaderboardstat
+
+type ScoreboardResponse struct {
+	Entries []ScoreboardItem
+}
+type ScoresListResponse struct{}
+
+type CategoryList int
+
+const (
+	global CategoryList = iota
+	cdp
+	eebi
+	mapserver
+	beehive
+	rankr
+)
+
+type LeaderboardFilterRequest struct {
+	Category  CategoryList `koanf:"category"`
+	Timeframe string       `koanf:"timeframe"`
+	Page      int          `koanf:"page"`
+	PageSize  int          `koanf:"page_size"`
+}

--- a/leaderboardstatapp/service/leaderboardstat/service.go
+++ b/leaderboardstatapp/service/leaderboardstat/service.go
@@ -1,0 +1,63 @@
+package leaderboardstat
+
+import (
+	"context"
+)
+
+type Repository interface {
+	GetLeaderboardByFilters(ctx context.Context, page int, pageSize int, list CategoryList, timeframe string) ([]ScoreboardItem, error)
+	CreateNewScoreList(ctx context.Context, redisKey string, entries []LeaderboardEntry) error
+}
+
+type Service struct {
+	repository Repository
+}
+
+// GetScoreboard for public leaderboard
+func (s *Service) GetLeaderboardByFilters(ctx context.Context, req LeaderboardFilterRequest) (ScoreboardResponse, error) {
+	page := req.Page
+	pageSize := req.PageSize
+	if page == 0 {
+		page = 1
+	}
+	if pageSize == 0 {
+		pageSize = 10
+	}
+	category := req.Category
+	// TODO - timeframe validation
+	timeframe := req.Timeframe
+
+	scoreboard, err := s.repository.GetLeaderboardByFilters(ctx, page, pageSize, category, timeframe)
+	if err != nil {
+		return ScoreboardResponse{}, err
+	}
+
+	return ScoreboardResponse{Entries: scoreboard}, nil
+}
+
+// GetContributorScores for user profile
+func GetContributorScores(contributorID int, project string) ScoresListResponse {
+
+	return ScoresListResponse{}
+}
+
+func (s *Service) CreateNewScoreList(ctx context.Context, redisKey string, entries []LeaderboardEntry) error {
+	err := s.repository.CreateNewScoreList(ctx, redisKey, entries)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Service) GetContributorStats(ctx context.Context, contributorID int) (ContributorStat, error) {
+	// TODO - implement functions and calc contributions stats related to this contributor
+
+	stats := ContributorStat{
+		ContributorID: contributorID,
+		GlobalRank:    0,
+		TotalScore:    0,
+		ProjectScore:  map[string]int{},
+		ScoreHistory:  map[string]int{},
+	}
+	return stats, nil
+}


### PR DESCRIPTION
Resolves #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added REST API to fetch leaderboard data with filtering (category, timeframe) and pagination; responses returned as JSON.
  - Introduced endpoint to retrieve an individual contributor’s stats, including rank and scores.
  - Added a health check endpoint for quick service status verification.
  - Server now registers versioned routes under /v1 for clearer API organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->