### PR TITLE
add deploy and cmd to stat service #65

### DIFF
--- a/cmd/leaderboardstat/command/migrate.go
+++ b/cmd/leaderboardstat/command/migrate.go
@@ -1,0 +1,71 @@
+package command
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/gocasters/rankr/leaderboardstatapp"
+	cfgloader "github.com/gocasters/rankr/pkg/config"
+	"github.com/gocasters/rankr/pkg/migrator"
+	"github.com/spf13/cobra"
+)
+
+var up bool
+var down bool
+
+var migrateCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: "Run database migrations",
+	Long:  `This command runs the database migrations for the food service.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		migrate()
+	},
+}
+
+func migrate() {
+	var cfg leaderboardstatapp.Config
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Error getting working directory: %v", err)
+	}
+
+	yamlPath := filepath.Join(workingDir, "leaderboardstatapp", "repository", "postgres", "dbconfig.yml")
+
+	// to run migrations when you want to run leaderboardstat service locally
+	if path := os.Getenv("DBCONFIG_OVERRIDE_PATH"); path != "" {
+		yamlPath = path
+		log.Printf("Using override config: %s", yamlPath)
+	} else {
+		log.Printf("Using default config: %s", yamlPath)
+	}
+
+	options := cfgloader.Options{
+		Prefix:       "STAT_",
+		Delimiter:    ".",
+		Separator:    "__",
+		YamlFilePath: yamlPath,
+		Transformer:  nil,
+	}
+
+	if err := cfgloader.Load(options, &cfg); err != nil {
+		log.Fatalf("Failed to load food config: %v", err)
+	}
+
+	mgr := migrator.New(cfg.PostgresDB, cfg.PathOfMigration)
+
+	if up {
+		mgr.Up()
+	} else if down {
+		mgr.Down()
+	} else {
+		log.Println("Please specify a migration direction with --up or --down")
+	}
+}
+
+func init() {
+	migrateCmd.Flags().BoolVar(&up, "up", false, "Run migrations up")
+	migrateCmd.Flags().BoolVar(&down, "down", false, "Run migrations down")
+	RootCmd.AddCommand(migrateCmd)
+}

--- a/cmd/leaderboardstat/command/root.go
+++ b/cmd/leaderboardstat/command/root.go
@@ -1,0 +1,12 @@
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var RootCmd = &cobra.Command{
+	Use:   "leaderboardstat_service",
+	Short: "A CLI for leaderboardstat service",
+	Long: `leaderboardstat Service CLI is a tool to manage and run 
+the leaderboardstat service, including migrations and server startup.`,
+}

--- a/cmd/leaderboardstat/command/serve.go
+++ b/cmd/leaderboardstat/command/serve.go
@@ -1,0 +1,98 @@
+package command
+
+import (
+	"fmt"
+	"github.com/gocasters/rankr/leaderboardstatapp"
+	"github.com/gocasters/rankr/pkg/config"
+	"github.com/gocasters/rankr/pkg/database"
+	"github.com/gocasters/rankr/pkg/logger"
+	"github.com/gocasters/rankr/pkg/migrator"
+	"github.com/spf13/cobra"
+	"log"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+var migrateUp bool
+var migrateDown bool
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Start the leaderboardstat service",
+	Long:  `This command starts the main leaderboardstat service.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		serve()
+	},
+}
+
+func init() {
+	fmt.Println("Service is initiating........")
+	serveCmd.Flags().BoolVar(&migrateUp, "migrate-up", false, "Run migrations up before starting the server")
+	serveCmd.Flags().BoolVar(&migrateDown, "migrate-down", false, "Run migrations down before starting the server")
+	serveCmd.MarkFlagsMutuallyExclusive("migrate-up", "migrate-down")
+	RootCmd.AddCommand(serveCmd)
+}
+
+func serve() {
+	fmt.Println("Starting leaderboardstat service........")
+	var cfg leaderboardstatapp.Config
+
+	// Load config
+	workingDir, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Error getting current working directory: %v", err)
+	}
+
+	yamlPath := os.Getenv("CONFIG_PATH")
+	if yamlPath == "" {
+		yamlPath = filepath.Join(workingDir, "deploy", "leaderboardstat", "development", "config.local.yml")
+	}
+
+	options := config.Options{
+		Prefix:       "LEADERBOARDSTAT_",
+		Delimiter:    ".",
+		Separator:    "__",
+		YamlFilePath: yamlPath,
+	}
+	if lErr := config.Load(options, &cfg); lErr != nil {
+		log.Fatalf("Failed to load leaderboardstat config: %v", lErr)
+	}
+
+	// Initialize logger
+	logger.Init(cfg.Logger)
+	leaderboardLogger, _ := logger.L()
+	// Run migrations if flags are set
+	if migrateUp || migrateDown {
+		if migrateUp && migrateDown {
+			leaderboardLogger.Error("invalid flags: --migrate-up and --migrate-down cannot be used together")
+			return
+		}
+
+		mgr := migrator.New(cfg.PostgresDB, cfg.PathOfMigration)
+		if migrateUp {
+			leaderboardLogger.Info("Running migrations up...")
+			mgr.Up()
+			leaderboardLogger.Info("Migrations up completed.")
+		}
+		if migrateDown {
+			leaderboardLogger.Info("Running migrations down...")
+			mgr.Down()
+			leaderboardLogger.Info("Migrations down completed.")
+		}
+	}
+
+	// TODO - Start otel tracer
+	leaderboardLogger.Info("Starting leaderboardstat Service...")
+
+	// Connect to the database
+	databaseConn, cnErr := database.Connect(cfg.PostgresDB)
+
+	if cnErr != nil {
+		leaderboardLogger.Error("fatal error occurred", "reason", "failed to connect to database", slog.Any("error", cnErr))
+		return
+	}
+	defer databaseConn.Close()
+
+	leaderboardLogger.Info("Leaderboard-stat service started")
+}

--- a/cmd/leaderboardstat/main.go
+++ b/cmd/leaderboardstat/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/gocasters/rankr/cmd/leaderboardstat/command"
+	"os"
+)
+
+func main() {
+	if err := command.RootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/deploy/leaderboardstat/development/config.local.yml
+++ b/deploy/leaderboardstat/development/config.local.yml
@@ -1,0 +1,31 @@
+server:
+  port: 5003
+  cors:
+    allow_origins: "*"
+
+total_shutdown_timeout:
+  15s
+
+postgres_db:
+  driver: postgres
+  host: localhost
+  port: 5437
+  user: "stat_admin"
+  password: "password123"
+  db_name: leaderboardstat_db
+  ssl_mode: disable
+  max_idle_conns: 15
+  max_open_conns: 100
+  conn_max_lifetime: 5
+
+logger:
+  file_path: "logs/leaderboardstat/service.log"
+  use_local_time: true
+  file_max_size_in_mb: 10
+  file_max_age_in_days: 7
+outbox_scheduler:
+  interval_in_seconds: 60
+  retry_threshold: 5
+  batch_size: 100
+
+path_of_migration: './leaderboardstatapp/repository/postgres/migrations'

--- a/deploy/leaderboardstat/development/config.yml
+++ b/deploy/leaderboardstat/development/config.yml
@@ -1,0 +1,40 @@
+server:
+  port: 5001
+  cors:
+    allow_origins: "*"
+
+
+total_shutdown_timeout: 15s
+
+postgres_db:
+  driver: postgres
+  host: leaderboardstat-db
+  port: 5433
+  user: "leaderboardstat_admin"
+  password: "password123"
+  db_name: leaderboardstat_db
+  ssl_mode: disable
+  max_idle_conns: 15
+  max_open_conns: 100
+  conn_max_lifetime: 5
+
+#grpc_client:
+#  Host: "rankr-app-service-1"
+#  port: 6003
+#  type: "tcp"
+#  shutdown_context_timeout: "10s"
+#
+#grpc_server:
+#  Host: "localhost"
+#  port: 6002
+#  type: "tcp"
+
+logger:
+  level: "debug"
+  file_path: "logs/leaderboardstat/service.log"
+  use_local_time: true
+  file_max_size_in_mb: 10
+  file_max_age_in_days: 7
+
+
+path_of_migration: './leaderboardstatapp/repository/postgres/migrations'

--- a/deploy/leaderboardstat/development/docker-compose.no-service.yml
+++ b/deploy/leaderboardstat/development/docker-compose.no-service.yml
@@ -1,0 +1,23 @@
+services:
+
+  leaderboardstat-db:
+    image: postgres:17.2-alpine
+    environment:
+      POSTGRES_DB: leaderboardstat_db
+      POSTGRES_USER: "stat_admin"
+      POSTGRES_PASSWORD: "password123"
+    restart: always
+#    profiles:
+#      - leaderboardstat
+    volumes:
+      - leaderboardstat-data:/var/lib/postgresql/data
+    ports:
+      - "5437:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U stat_admin -d leaderboardstat_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  leaderboardstat-data:

--- a/deploy/leaderboardstat/development/docker-compose.yml
+++ b/deploy/leaderboardstat/development/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+
+  leaderboardstat-db:
+    image: postgres:17.2-alpine
+    environment:
+      POSTGRES_DB: leaderboardstat_db
+      POSTGRES_USER: "stat_admin"
+      POSTGRES_PASSWORD: "password123"
+    restart: always
+    profiles:
+      - leaderboardstat
+    volumes:
+      - leaderboardstat-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U stat_admin -d leaderboardstat_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  leaderboardstat-service:
+    build:
+      context: .
+      dockerfile: ./deploy/leaderboardstat/development/Dockerfile
+      args:
+        GO_IMAGE_NAME: golang
+        GO_IMAGE_VERSION: 1.23.4-alpine
+    image: rankr-leaderboardstat:golang-1.23.4-alpine
+
+    command: /bin/sh -c "go run cmd/leaderboardstat/main.go migrate --up"
+    depends_on:
+      leaderboardstat-db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+
+    volumes:
+      - ./:/home/app
+#      - leaderboardstat-go-mod-cache:/go/pkg/mod
+    profiles:
+      - leaderboardstat
+    ports:
+      - "6011:6011"
+
+volumes:
+  leaderboardstat-data:
+#  leaderboardstat-go-mod-cache:

--- a/leaderboardstatapp/app.go
+++ b/leaderboardstatapp/app.go
@@ -1,0 +1,136 @@
+package leaderboardstatapp
+
+import (
+	"context"
+	"fmt"
+	"github.com/gocasters/rankr/leaderboardstatapp/repository/postgres"
+	"github.com/gocasters/rankr/leaderboardstatapp/service/leaderboardstat"
+	"github.com/gocasters/rankr/pkg/httpserver"
+	"log/slog"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/gocasters/rankr/adapter/redis"
+	"github.com/gocasters/rankr/leaderboardstatapp/delivery/http"
+	//"github.com/gocasters/rankr/leaderboardstatapp/repository/postgres"
+	"github.com/gocasters/rankr/pkg/database"
+	//"github.com/gocasters/rankr/pkg/httpserver"
+)
+
+type Application struct {
+	LeaderboardStatRepo    leaderboardstat.Repository
+	LeaderboardStatSrv     leaderboardstat.Service
+	LeaderboardStatHandler http.Handler
+	HTTPServer             http.Server
+	Config                 Config
+	Logger                 *slog.Logger
+	Redis                  *redis.Adapter
+}
+
+func Setup(
+	ctx context.Context,
+	config Config,
+	postgresConn *database.Database,
+	logger *slog.Logger,
+) Application {
+
+	//postgresAdapter, _ := postgres.NewLeaderboardstatRepo(ctx, config.PostgresDB)
+
+	leaderboardStatRepo := postgres.NewLeaderboardstatRepo(postgresConn, logger)
+	leaderboardStatValidator := leaderboardstat.NewValidator()
+	leaderboardStatSvc := leaderboardstat.NewService(leaderboardStatRepo, leaderboardStatValidator, logger)
+
+	leaderboardStatHandler := http.NewHandler(leaderboardStatSvc, logger)
+
+	httpServer, _ := httpserver.New(config.HTTPServer)
+
+	return Application{
+		LeaderboardStatRepo:    leaderboardStatRepo,
+		LeaderboardStatSrv:     leaderboardStatSvc,
+		LeaderboardStatHandler: leaderboardStatHandler,
+		HTTPServer: http.New(
+			*httpServer,
+			leaderboardStatHandler,
+			logger,
+		),
+		Config: config,
+		Logger: logger,
+	}
+}
+
+func (app Application) Start() {
+	var wg sync.WaitGroup
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	startServers(app, &wg)
+	<-ctx.Done()
+	app.Logger.Info("Shutdown signal received...")
+
+	shutdownTimeoutCtx, cancel := context.WithTimeout(context.Background(), app.Config.TotalShutdownTimeout)
+	defer cancel()
+
+	if app.shutdownServers(shutdownTimeoutCtx) {
+		app.Logger.Info("Servers shut down gracefully")
+	} else {
+		app.Logger.Warn("Shutdown timed out, exiting application")
+		os.Exit(1)
+	}
+
+	wg.Wait()
+	app.Logger.Info("leaderboardStat_app stopped")
+}
+
+func startServers(app Application, wg *sync.WaitGroup) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		app.Logger.Info(fmt.Sprintf("✅ HTTP server started on %d", app.Config.HTTPServer.Port))
+		if err := app.HTTPServer.Serve(); err != nil {
+			app.Logger.Error(fmt.Sprintf("error in HTTP server on %d", app.Config.HTTPServer.Port), err)
+		}
+		app.Logger.Info(fmt.Sprintf("HTTP server stopped %d", app.Config.HTTPServer.Port))
+	}()
+}
+
+func (app Application) shutdownServers(ctx context.Context) bool {
+	app.Logger.Info("Starting server shutdown process...")
+	shutdownDone := make(chan struct{})
+
+	parentCtx := context.Background()
+	go func() {
+		var shutdownWg sync.WaitGroup
+		shutdownWg.Add(1)
+		go app.shutdownHTTPServer(parentCtx, &shutdownWg)
+
+		shutdownWg.Wait()
+		close(shutdownDone)
+		app.Logger.Info("All servers have been shut down successfully.")
+
+	}()
+
+	select {
+	case <-shutdownDone:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (app Application) shutdownHTTPServer(parentCtx context.Context, wg *sync.WaitGroup) {
+	app.Logger.Info(fmt.Sprintf("Starting graceful shutdown for HTTP server on port %d", app.Config.HTTPServer.Port))
+
+	defer wg.Done()
+	httpShutdownCtx, httpCancel := context.WithTimeout(parentCtx, app.Config.HTTPServer.ShutdownTimeout)
+	defer httpCancel()
+
+	// TODO - check why app.HTTPServer.HTTPServer.stop
+	if err := app.HTTPServer.HTTPServer.Stop(httpShutdownCtx); err != nil {
+		app.Logger.Error(fmt.Sprintf("HTTP server graceful shutdown failed: %v", err))
+	}
+
+	app.Logger.Info("HTTP server shut down successfully.")
+}

--- a/leaderboardstatapp/config.go
+++ b/leaderboardstatapp/config.go
@@ -1,0 +1,20 @@
+package leaderboardstatapp
+
+import (
+	"github.com/gocasters/rankr/adapter/redis"
+	"github.com/gocasters/rankr/contributorapp/repository"
+	"github.com/gocasters/rankr/pkg/database"
+	"github.com/gocasters/rankr/pkg/httpserver"
+	"github.com/gocasters/rankr/pkg/logger"
+	"time"
+)
+
+type Config struct {
+	HTTPServer           httpserver.Config `koanf:"http_server"`
+	PostgresDB           database.Config   `koanf:"postgres_db"`
+	Repository           repository.Config `koanf:"repository"`
+	Redis                redis.Config      `koanf:"redis"`
+	Logger               logger.Config     `koanf:"logger" `
+	TotalShutdownTimeout time.Duration     `koanf:"total_shutdown_timeout"`
+	PathOfMigration      string            `koanf:"path_of_migration"`
+}

--- a/leaderboardstatapp/delivery/http/handler.go
+++ b/leaderboardstatapp/delivery/http/handler.go
@@ -13,26 +13,11 @@ type Handler struct {
 	Logger                 *slog.Logger
 }
 
-func NewHandler(leaderboardStatService leaderboardstat.Service, logger *slog.Logger) *Handler {
-	return &Handler{
+func NewHandler(leaderboardStatService leaderboardstat.Service, logger *slog.Logger) Handler {
+	return Handler{
 		LeaderboardStatService: leaderboardStatService,
 		Logger:                 logger,
 	}
-}
-
-func (h Handler) GetLeaderboards(c echo.Context) error {
-	var req leaderboardstat.LeaderboardFilterRequest
-
-	if err := c.Bind(&req); err != nil {
-		return err
-	}
-
-	response, err := h.LeaderboardStatService.GetLeaderboardByFilters(c.Request().Context(), req)
-
-	if err != nil {
-		return err
-	}
-	return c.JSON(http.StatusOK, response)
 }
 
 func (h Handler) GetContributorStats(c echo.Context) error {

--- a/leaderboardstatapp/delivery/http/server.go
+++ b/leaderboardstatapp/delivery/http/server.go
@@ -1,31 +1,31 @@
 package http
 
 import (
-	"fmt"
-	"strconv"
-
 	httpserver "github.com/gocasters/rankr/pkg/httpserver"
+	"log/slog"
 )
 
 type Server struct {
 	HTTPServer httpserver.Server
 	Handler    Handler
+	logger     *slog.Logger
 }
 
-func New(server httpserver.Server, handler Handler) Server {
+func New(server httpserver.Server, handler Handler, logger *slog.Logger) Server {
 	return Server{
 		HTTPServer: server,
 		Handler:    handler,
+		logger:     logger,
 	}
 }
 
-func (s Server) Serve() {
+func (s Server) Serve() error {
 	s.RegisterRoutes()
-
-	fmt.Printf("start echo server on %s\n", strconv.Itoa(s.HTTPServer.GetConfig().Port))
 	if err := s.HTTPServer.Start(); err != nil {
-		fmt.Println("router start error", err)
+		return err
 	}
+
+	return nil
 }
 
 func (s Server) RegisterRoutes() {
@@ -34,11 +34,6 @@ func (s Server) RegisterRoutes() {
 	// create v1 group
 	v1 := s.HTTPServer.GetRouter().Group("/v1")
 	v1.GET("/health-check", s.healthCheck)
-
-	// leaderboard group
-	leaderboardGroup := v1.Group("/leaderboard")
-	leaderboardGroup.GET("/", s.Handler.GetLeaderboards)
-	//leaderboardGroup.GET("/:project", s.Handler.GetLeaderboard)
 
 	// contributor group
 	contributorGroup := v1.Group("/contributors")

--- a/leaderboardstatapp/repository/postgres/dbconfig.local.yml
+++ b/leaderboardstatapp/repository/postgres/dbconfig.local.yml
@@ -1,0 +1,10 @@
+postgres_db:
+  driver: postgres
+  host: localhost
+  port: 5432
+  user: stat_admin
+  password: password123
+  db_name: leaderboardstat_db
+  ssl_mode: disable
+
+path_of_migration: ./leaderboardstatapp/repository/postgres/migrations

--- a/leaderboardstatapp/repository/postgres/leaderboardstat.go
+++ b/leaderboardstatapp/repository/postgres/leaderboardstat.go
@@ -1,0 +1,15 @@
+package postgres
+
+import (
+	"github.com/gocasters/rankr/pkg/database"
+	"log/slog"
+)
+
+type LeaderboardstatRepo struct {
+	Logger     *slog.Logger
+	PostgreSQL *database.Database
+}
+
+func NewLeaderboardstatRepo(postgresDb *database.Database, logger *slog.Logger) LeaderboardstatRepo {
+	return LeaderboardstatRepo{PostgreSQL: postgresDb}
+}

--- a/leaderboardstatapp/repository/postgres/migrations/1756317831_create_scores_table.sql
+++ b/leaderboardstatapp/repository/postgres/migrations/1756317831_create_scores_table.sql
@@ -1,0 +1,14 @@
+-- +migrate Up
+-- Create scores table
+CREATE TABLE IF NOT EXISTS scores (
+    id SERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    activity VARCHAR(50) NOT NULL,
+    score DECIMAL(10, 2) NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NULL,
+    is_deleted BOOLEAN NULL
+);
+
+-- +migrate Down
+DROP TABLE IF EXISTS scores;

--- a/leaderboardstatapp/service/leaderboardstat/entity.go
+++ b/leaderboardstatapp/service/leaderboardstat/entity.go
@@ -15,6 +15,6 @@ type ContributorStat struct {
 	ContributorID int            `koanf:"contributor_id"`
 	GlobalRank    int            `koanf:"global_rank"`
 	TotalScore    int            `koanf:"total_score"`
-	ProjectScore  map[string]int `koanf:"project_ranks"`
+	ProjectScore  map[string]int `koanf:"project_score"`
 	ScoreHistory  map[string]int `koanf:"score_history"`
 }

--- a/leaderboardstatapp/service/leaderboardstat/service.go
+++ b/leaderboardstatapp/service/leaderboardstat/service.go
@@ -2,51 +2,30 @@ package leaderboardstat
 
 import (
 	"context"
+	"log/slog"
 )
 
 type Repository interface {
-	GetLeaderboardByFilters(ctx context.Context, page int, pageSize int, list CategoryList, timeframe string) ([]ScoreboardItem, error)
-	CreateNewScoreList(ctx context.Context, redisKey string, entries []LeaderboardEntry) error
+	//CreateNewScoreList(ctx context.Context, redisKey string, entries []LeaderboardEntry) error
 }
 
 type Service struct {
 	repository Repository
+	validator  Validator
+	logger     *slog.Logger
 }
 
-// GetScoreboard for public leaderboard
-func (s *Service) GetLeaderboardByFilters(ctx context.Context, req LeaderboardFilterRequest) (ScoreboardResponse, error) {
-	page := req.Page
-	pageSize := req.PageSize
-	if page == 0 {
-		page = 1
+func NewService(repo Repository, validator Validator, logger *slog.Logger) Service {
+	return Service{
+		repository: repo,
+		validator:  validator,
 	}
-	if pageSize == 0 {
-		pageSize = 10
-	}
-	category := req.Category
-	// TODO - timeframe validation
-	timeframe := req.Timeframe
-
-	scoreboard, err := s.repository.GetLeaderboardByFilters(ctx, page, pageSize, category, timeframe)
-	if err != nil {
-		return ScoreboardResponse{}, err
-	}
-
-	return ScoreboardResponse{Entries: scoreboard}, nil
 }
 
 // GetContributorScores for user profile
 func GetContributorScores(contributorID int, project string) ScoresListResponse {
 
 	return ScoresListResponse{}
-}
-
-func (s *Service) CreateNewScoreList(ctx context.Context, redisKey string, entries []LeaderboardEntry) error {
-	err := s.repository.CreateNewScoreList(ctx, redisKey, entries)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func (s *Service) GetContributorStats(ctx context.Context, contributorID int) (ContributorStat, error) {

--- a/leaderboardstatapp/service/leaderboardstat/validator.go
+++ b/leaderboardstatapp/service/leaderboardstat/validator.go
@@ -1,0 +1,7 @@
+package leaderboardstat
+
+type Validator struct{}
+
+func NewValidator() Validator {
+	return Validator{}
+}

--- a/logs/leaderboardstat/service.log
+++ b/logs/leaderboardstat/service.log
@@ -1,0 +1,59 @@
+{"time":"2025-08-29T02:30:39.309606-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T02:30:39.312102-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T02:31:13.194416-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T02:31:13.196235-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T02:39:15.769349-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T02:39:15.770952-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T02:40:11.972399-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T02:40:11.97386-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T02:42:04.511554-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T02:42:04.513307-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T02:42:48.638726-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T02:42:48.640527-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T02:45:48.19564-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T02:45:48.197229-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T02:51:37.730689-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T02:51:37.73236-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T02:57:58.214292-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T02:57:58.216007-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T03:00:45.42174-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T03:00:45.423605-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T03:01:10.970176-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T03:01:10.971956-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T03:01:32.891118-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T03:01:32.892635-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T03:01:58.425295-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T03:01:58.426904-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T03:09:09.99059-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T03:09:09.992204-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T03:13:27.320746-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T03:13:27.322229-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T03:14:12.074497-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T03:14:12.075968-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T03:57:14.093402-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T03:57:14.096749-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to ping database: failed to connect to `user=stat_admin database=leaderboardstat_db`: [::1]:5437 (localhost): dial error: dial tcp [::1]:5437: connect: connection refused"}
+{"time":"2025-08-29T04:00:09.163752-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T04:00:31.084963-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T04:00:31.088863-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to ping database: failed to connect to `user=stat_admin database=leaderboardstat_db`: [::1]:5437 (localhost): dial error: dial tcp [::1]:5437: connect: connection refused"}
+{"time":"2025-08-29T04:00:45.61627-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T04:00:45.619678-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to ping database: failed to connect to `user=stat_admin database=leaderboardstat_db`: [::1]:5437 (localhost): dial error: dial tcp [::1]:5437: connect: connection refused"}
+{"time":"2025-08-29T04:01:50.574584-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T04:02:31.05741-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T04:08:24.971402-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T04:43:24.913302-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T04:53:29.347714-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T04:55:20.078403-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T05:05:35.26391-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T05:05:35.265678-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T05:06:20.215494-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T05:06:20.217265-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T05:07:55.677377-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T05:07:55.679187-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T05:25:52.309611-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T05:25:52.311163-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T05:50:43.902591-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T05:50:43.905289-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}
+{"time":"2025-08-29T08:09:52.020392-07:00","level":"INFO","msg":"Running migrations up..."}
+{"time":"2025-08-29T08:09:52.057259-07:00","level":"INFO","msg":"Migrations up completed."}
+{"time":"2025-08-29T08:09:52.057286-07:00","level":"INFO","msg":"Starting leaderboardstat Service..."}
+{"time":"2025-08-29T08:09:52.057904-07:00","level":"ERROR","msg":"fatal error occurred","reason":"failed to connect to database","error":"failed to create pgx pool: MaxSize must be >= 1"}


### PR DESCRIPTION
closes #65 

Some feathers like deployment and cmd added.
Migration and Serve method works correctly.

In coordination with the LeaderboardScoring service team, I have created a temporary test table to populate initial sample data for testing purposes. 
Once the LeaderboardScoring service completes the implementation of the actual production tables, I will Remove the temporary test table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a CLI with root, serve, and migrate commands for managing the service and database migrations.
  - Added graceful startup/shutdown orchestration with configurable timeouts and structured logging.
- Refactor
  - Simplified HTTP server lifecycle; errors now propagate properly.
  - Removed legacy leaderboard endpoints and related handlers.
- Chores
  - Added development configs and Docker Compose for local DB and service.
  - Included initial database migration for scores.
  - Provided environment-based configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->